### PR TITLE
Fix documentation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ var angelsAndDemons = {
   author: 'Dan Brown'
 };
 
-var search = new Search('isbn');
+var search = new JsSearch.Search('isbn');
 search.addIndex('title');
 search.addIndex('author');
 search.addDocuments([theGreatGatsby, theDaVinciCode, angelsAndDemons]);


### PR DESCRIPTION
Couldn’t get lib to work with a call to ‘new Search’.
Also appears the example page http://bvaughn.github.io/js-search/ uses
this updated call.