### PR TITLE
Pass query to search index function

### DIFF
--- a/source/search-index/search-index.ts
+++ b/source/search-index/search-index.ts
@@ -22,6 +22,6 @@ module JsSearch {
      * @param corpus All document in search corpus
      * @param tokens
      */
-    search(tokens:Array<string>, corpus:Array<Object>):Array<Object>;
+    search(query:string, tokens:Array<string>, corpus:Array<Object>):Array<Object>;
   };
 };

--- a/source/search-index/tf-idf-search-index.ts
+++ b/source/search-index/tf-idf-search-index.ts
@@ -48,7 +48,7 @@ module JsSearch {
     /**
      * @inheritDocs
      */
-    public search(tokens:Array<string>, corpus:Array<Object>):Array<Object> {
+    public search(query:string, tokens:Array<string>, corpus:Array<Object>):Array<Object> {
       var uidToDocumentMap:{[uid:string]:Object} = {};
 
       for (var i = 0, numTokens = tokens.length; i < numTokens; i++) {

--- a/source/search-index/unordered-search-index.ts
+++ b/source/search-index/unordered-search-index.ts
@@ -27,7 +27,7 @@ module JsSearch {
     /**
      * @inheritDocs
      */
-    public search(tokens:Array<string>, corpus:Array<Object>):Array<Object> {
+    public search(query:string, tokens:Array<string>, corpus:Array<Object>):Array<Object> {
       var uidToDocumentMap:{[uid:string]:any} = {};
 
       for (var i = 0, numTokens = tokens.length; i < numTokens; i++) {

--- a/source/search.ts
+++ b/source/search.ts
@@ -148,7 +148,7 @@ module JsSearch {
     public search(query:string):Array<Object> {
       var tokens:Array<string> = this.tokenizer_.tokenize(this.sanitizer_.sanitize(query));
 
-      return this.searchIndex_.search(tokens, this.documents_);
+      return this.searchIndex_.search(query, tokens, this.documents_);
     }
 
     /**


### PR DESCRIPTION
Query was a parameter as indicated in the docs, but wasn't actually passed. This could be helpful if the index is based on the query (e.g. I query 'egg' and I want 'eggplant' to appear before 'beggar').