### PR TITLE
Add import statement to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ objects to be searched.
 For example, a simple use of JS Search would be as follows:
 
 ```javascript
+import * as JsSearch from 'js-search';
+
 var theGreatGatsby = {
   isbn: '9781597226769',
   title: 'The Great Gatsby',


### PR DESCRIPTION
I had to search for how to import the library properly. I propose that the line 'import * as JsSearch from 'js-search';' is added to the js example section.