### PR TITLE
 Don't inherit from the default Object for the token dictionary

### DIFF
--- a/source/TokenHighlighter.js
+++ b/source/TokenHighlighter.js
@@ -40,7 +40,7 @@ export class TokenHighlighter {
   highlight(text : string, tokens : Array<string>) {
     var tagsLength : number = this._wrapText('').length;
 
-    var tokenDictionary = {};
+    var tokenDictionary = Object.create(null);
 
     // Create a token map for easier lookup below.
     for (var i = 0, numTokens = tokens.length; i < numTokens; i++) {


### PR DESCRIPTION
Ran into a problem tokenizing the string "[name] Constructors, LLC", since at some point `expandedToken` is `'constructor'`, which is valid default object function.
aka
```
({})['constructor']
> ƒ Object() { [native code] }
```
This uses a an object that doesn't inherent the Object functions for the `tokenDictionary`, getting around the issue.