### PR TITLE
Capability to search in nested arrays of objects

### DIFF
--- a/source/Search.test.js
+++ b/source/Search.test.js
@@ -1,7 +1,7 @@
 import { Search } from './Search';
 
 describe('Search', function() {
-  var documentBar, documentBaz, documentFoo, nestedDocumentFoo, search;
+  var documentBar, documentBaz, documentFoo, nestedDocumentFoo, nestedArrayDocumentFoo, search;
 
   var validateSearchResults = function(results, expectedDocuments) {
     expect(results.length).toBe(expectedDocuments.length);
@@ -42,6 +42,15 @@ describe('Search', function() {
         title: 'nested foo'
       }
     }
+    nestedArrayDocumentFoo = {
+      uid: 'foo',
+      title: 'foo',
+      description: 'Is kung foo the same as kung fu?',
+      writers: [
+        { name: 'ABC' },
+        { name: 'xyz' }
+      ]
+    };
   });
 
   it('should throw an error if instantiated without the :uidFieldName parameter', function() {
@@ -113,6 +122,13 @@ describe('Search', function() {
     search.addDocument(nestedDocumentFoo);
 
     validateSearchResults(search.search('nested foo'), [nestedDocumentFoo]);
+  });
+
+  it('should index nested arrays document properties', function() {
+    search.addIndex(['writers', '[]', 'name']);
+    search.addDocument(nestedArrayDocumentFoo);
+
+    validateSearchResults(search.search('ABC'), [nestedArrayDocumentFoo]);
   });
 
   it('should gracefully handle broken property path', function() {

--- a/source/Search.test.js
+++ b/source/Search.test.js
@@ -49,6 +49,13 @@ describe('Search', function() {
       writers: [
         { name: 'ABC' },
         { name: 'xyz' }
+      ],
+      deeplyNested: [
+        {
+          writers: [
+            { name: 'deeply nested name'}
+          ]
+        }
       ]
     };
   });
@@ -129,6 +136,20 @@ describe('Search', function() {
     search.addDocument(nestedArrayDocumentFoo);
 
     validateSearchResults(search.search('ABC'), [nestedArrayDocumentFoo]);
+  });
+
+  it('should index deeply nested arrays document properties', function() {
+    search.addIndex(['deeplyNested', '[]', 'writers', '[]', 'name']);
+    search.addDocument(nestedArrayDocumentFoo);
+
+    validateSearchResults(search.search('deeply nested'), [nestedArrayDocumentFoo]);
+  });
+
+  it('should not give false results for deeply nested arrays document properties', function() {
+    search.addIndex(['deeplyNested', '[]', 'writers', '[]', 'name']);
+    search.addDocument(nestedArrayDocumentFoo);
+
+    validateSearchResults(search.search('something not findable'), []);
   });
 
   it('should gracefully handle broken property path', function() {

--- a/source/getNestedFieldValues.js
+++ b/source/getNestedFieldValues.js
@@ -1,0 +1,30 @@
+/**
+ * Find and return nested object values.
+ *
+ * @param object to crawl
+ * @param path Property path
+ * @returns {any}
+ */
+export default function getNestedFieldValues(object : Object, path : Array<string>) {
+  path = path || [];
+  object = object || {};
+
+  var values = [];
+  var value = object;
+  // walk down the property path
+  for (var i = 0; i < path.length; i++) {
+    if (path[i] == "[]") {
+      for (var j=0; j < value.length; j++) {
+        values = values.concat(getNestedFieldValues(value[j], path.slice(i + 1, path.length)));
+      }
+      return values;
+    } else {
+      value = value[path[i]];
+      if (value == null || value == undefined) {
+        return [];
+      }
+    }
+  }
+
+  return [value];
+}


### PR DESCRIPTION
```
{
  isbn: '9781597226769',
  title: 'The Great Gatsby',
  authors: [
    {
        name: 'F. Scott Fitzgerald'
    },
    {
        name: 'James D'
    }
  ],
  tags: ['book', 'inspirational']
}
```

Allows to search in deeply nested arrays with syntax suggested in #47 , i.e: `['authors', '[]', 'name']` for above example.

Solves #47 and #77 .

**PS:** If there is anything we can improve in this PR, i am happy to do that. One thing i know is that I could probably make change in existing `getNestedFieldValue` function instead of making a new `getNestedFieldValues` function. But that seemed to have far more consequences and we needed this support ASAP.